### PR TITLE
[CT-049] Adiciona uma descrição padrão para os PRs do repo #6

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Porque esse PR foi criado? 🤔
+[Descrição do problema que está sendo resolvido]
+
+## O que foi feito? 🧰
+[Descreva como o problema foi resolvido] 
+
+Cite aqui:
+- Features
+- Bugfixes
+- Configurações no ambiente (desenvolvimento ou produção)
+- Testes unitários
+
+Adicione aqui também imagens, vídeos ou gifs demonstrativos, preferencialmente em formato de tabela
+
+## ✅ Como validar esse PR?
+[Adicione os passos enumerados para realizar os testes]
+
+## ⚠️ Observações
+[Adicione aqui impeditivos e observações sobre o que foi adicionado/alterado]
+[Ex: deploy está bloqueado por X motivo; essa alteração quebra X comportamento; para fazer deploy é necessário...]
+
+## 📚 Referências
+[Adicione aqui link para tarefas do board, documentações e etc]
+
+## 👥 Colaboradores
+[Adicione aqui menções à usuários que participaram do desenvolvimento]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Porque esse PR foi criado? 🤔
+## Por que esse PR foi criado? 🤔
 [Descrição do problema que está sendo resolvido]
 
 ## O que foi feito? 🧰


### PR DESCRIPTION
## Porque esse PR foi criado? 🤔
Esse PR adiciona um template padrão para descrição de pull-requests para esse repositório.

## O que foi feito? 🧰
- Features
  - Adicionado um arquivo .github/pull_request_template.md que o github configura como padrão sempre que for aberto um PR.


## ✅ Como validar esse PR?
- Use uma branch com alterações diferentes da main
- Tente criar um Pull-Request
- Valide se é possível visualizar o novo template definido

## 📚 Referências
- [Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)