### PR TITLE
[CT-029] Adiciona componentes visuais da página de despesas

### DIFF
--- a/expenses-dashboard.html
+++ b/expenses-dashboard.html
@@ -3,11 +3,67 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cashtrack</title>
-    <link rel="stylesheet" href="./css/index.css">
+    <title>Cashtrack - Dashboard</title>
+    <link rel="stylesheet" href="./css/dashboard.css">
     <link rel="icon" href="./assets/images/logo.png" type="image/png">
+
+    <!-- AOS Library - used for scroll and fade animations-->
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <!-- Font awrsome - used for icons on the code -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <!-- Chart.js -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
+    <!-- Modal for the register message -->
+    <div id="messageModal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <p id="modalMessage"></p>
+        </div>
+    </div>
+    <!-- Modal for editing objects -->
+    <div id="editModal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <h3 id="editModalTitle"></h3>
+            <form id="editExpenseForm">
+                <label for="editExpenseLabel">Nome:</label>
+                <input type="text" id="editExpenseLabel" required>
+                <label for="value">Valor (R$):</label>
+                <input type="number" id="editExpenseValue" name="value" required>
+                <label>Tipo:</label>
+                <select id="editExpenseType" name="type" required class="type-select-expenses">
+                    <option value="MONTHLY_ESSENTIAL">Gastos mensais</option>
+                    <option value="ENTERTAINMENT">Entretenimento</option>
+                    <option value="INVESTMENTS">Investimentos</option>
+                    <option value="LONGTIME_PURCHASE">Longo prazo</option>
+                </select>
+                <button type="submit">Editar</button>
+            </form>
+        </div>
+    </div>
+    <!-- Modal for adding new entry/expense -->
+    <div id="addModal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <h3 id="modalTitle"></h3>
+            <form id="addFormExpense">
+                <label for="expenseLabel">Nome:</label>
+                <input type="text" id="expenseLabel" required>
+                <label for="value">Valor (R$):</label>
+                <input type="number" id="value-expense" name="value" required>
+                <label>Tipo:</label>
+                <select id="type-select-expenses" name="type" required class="type-select-expenses">
+                    <option value="MONTHLY_ESSENTIAL">Gastos mensais</option>
+                    <option value="ENTERTAINMENT">Entretenimento</option>
+                    <option value="INVESTMENTS">Investimentos</option>
+                    <option value="LONGTIME_PURCHASE">Longo prazo</option>
+                </select>
+                <button type="submit">Adicionar</button>
+            </form>
+        </div>
+    </div>
     <!-- Navbar -->
     <header data-aos="fade-down">
         <div class="container">
@@ -33,11 +89,29 @@
     </header>
     <!-- Main Content -->
     <main>
-        <h1>[expenses-dashboard] </h1>
+        <div class="cards-container" data-aos="fade-up"></div>
+            <div class="card red-card" data-aos="fade-up">
+                <h3>Despesas</h3>
+                <p>Total de Despesas: <span id="total-expenses"></span></p>
+                <button id="add-expense-btn">Adicionar Nova Despesa</button>
+                <ul id="expenses-list"></ul>
+            </div>
+            <div class="card" data-aos="fade-up">
+                <h3>Suas despesas ao longo do tempo</h3>
+                <canvas id="expensesChart"></canvas>
+            </div>
+        </div>
     </main>
     <!-- Footer -->
     <footer>
-        <p><a style="color: #C0B7B1;" href="./ye.html">&copy; 2024 Cashtrack. Todos os direitos reservados.</a></p>
+        <p>&copy; 2024 Cashtrack. Todos os direitos reservados.</p>
     </footer>
 </body>
 </html>
+<!-- Scripts -->
+<script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+<script>
+    AOS.init();
+</script>
+<script src="./js/expenses-dashboard.js"></script>
+<script src="./js/expenses-add-new.js"></script>

--- a/js/expenses-add-new.js
+++ b/js/expenses-add-new.js
@@ -1,0 +1,86 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const modal = document.getElementById('addModal');
+    const modalTitle = document.getElementById('modalTitle');
+    const expenseForm = document.getElementById('addFormExpense');
+    const expenseLabel = document.getElementById('expenseLabel');
+    const typeExpense = document.getElementById('type-select-expenses');
+    const valueExpense = document.getElementById('value-expense')
+    // Message modal for error or success messages
+    const messageModal = document.getElementById('messageModal');
+    const closeModal = modal.querySelector('.close');
+
+    function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+    }
+
+    const accessToken = getCookie('accessToken');
+
+    //Function to show the add new expense/income modal
+    function showModal(title, type) {
+        expenseForm.style.display = 'flex';
+        modalTitle.textContent = title;
+        modal.style.display = 'flex';
+
+        modal.querySelector('.close').addEventListener('click', () => {
+            modal.style.display = 'none';
+        });
+
+        window.addEventListener('click', (event) => {
+            if (event.target == modal) {
+                modal.style.display = 'none';
+            }
+        });
+    }
+
+    function showMessage(message) {
+        messageModal.textContent = message;
+        modal.style.display = 'block';
+
+        closeModal.addEventListener('click', () => {
+            modal.style.display = 'none';
+        });
+
+        window.addEventListener('click', (event) => {
+            if (event.target == modal) {
+                modal.style.display = 'none';
+            }
+        });
+    }
+
+    document.getElementById('add-expense-btn').addEventListener('click', () => {
+        showModal('Adicionar Nova Despesa', 'expense');
+    });
+
+    document.getElementById('addFormExpense').addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const data = { 
+            expenseLabel: expenseLabel.value,
+            value: parseFloat(valueExpense.value),
+            type: typeExpense.value
+        }
+
+        try {
+            const response = await fetch(`${API_URL}/expenses`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${accessToken}`
+                },
+                credentials: 'include',
+                body: JSON.stringify(data)
+            });
+
+            if (response.status === 201) {
+                window.location.reload();
+            } else {
+               showMessage('Erro ao adicionar. Tente novamente.');
+            }
+        } catch (error) {
+            console.error('Erro ao enviar a requisição:', error);
+            showMessage('Erro ao adicionar. Tente novamente.');
+        }
+    });
+});s

--- a/js/expenses-dashboard.js
+++ b/js/expenses-dashboard.js
@@ -1,12 +1,349 @@
 const API_URL = 'https://cashtrack-deploy-production.up.railway.app';
 //const API_URL = 'http://localhost:8080';
 
+const typeTagMapping = {
+    'SALARY': 'Salário',
+    'EXTRA': 'Extras',
+    'GIFT': 'Presente',
+    'MONTHLY_ESSENTIAL': 'Essencial',
+    'ENTERTAINMENT': 'Lazer',
+    'INVESTMENTS': 'Investimento',
+    'LONGTIME_PURCHASE': 'Parcelamento'
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
     const burger = document.querySelector('.burger');
     const navLinks = document.querySelector('.nav-links');
+    const editModal = document.getElementById('editModal');
+    const editModalTitle = document.getElementById('editModalTitle');
+    const editExpenseForm = document.getElementById('editExpenseForm');
+    const editExpenseLabel = document.getElementById('editExpenseLabel');
+    const editExpenseType = document.getElementById('editExpenseType');
+    const editExpenseValue = document.getElementById('editExpenseValue');
+    // Message modal for error or success messages
+    const messageModal = document.getElementById('messageModal');
+    const modalMessage = document.getElementById('modalMessage');
+
+    function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+    }
+
+    const accessToken = getCookie('accessToken');
+    if (!accessToken) {
+        window.location.href = 'index.html';
+        return;
+    }
+
+    function deleteCookie(name) {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    }
+
+    function showMessage(message) {
+        modalMessage.textContent = message;
+        messageModal.style.display = 'flex';
+
+        messageModal.querySelector('.close').addEventListener('click', () => {
+            messageModal.style.display = 'none';
+        });
+
+        window.addEventListener('click', (event) => {
+            if (event.target == messageModal) {
+                messageModal.style.display = 'none';
+            }
+        });
+    }
+
+    function showEditModal(title, type, data) {
+        editExpenseForm.style.display = 'flex';
+        editExpenseLabel.value = data.expenseLabel;
+        editExpenseType.value = data.type;
+        editExpenseValue.value = data.value;
+        editModalTitle.textContent = title;
+        editModal.style.display = 'flex';
+
+        editModal.querySelector('.close').addEventListener('click', () => {
+            editModal.style.display = 'none';
+        });
+
+        window.addEventListener('click', (event) => {
+            if (event.target == editModal) {
+                editModal.style.display = 'none';
+            }
+        });
+    }
+
+    try {
+        const transactionsResponse = await fetch(`${API_URL}/users/balance`, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`
+            },
+        });
+
+        if (transactionsResponse.ok) {
+            const transactionsData = await transactionsResponse.json();
+            const expenseElement = document.getElementById('total-expenses');
+            if (expenseElement) {
+                expenseElement.textContent = `R$ ${transactionsData.totalExpenses.toFixed(2)}`;
+            }
+        } else {
+            console.error('Erro ao obter as transações do usuário');
+        }
+    } catch (error) {
+        console.error('Erro ao enviar a requisição');
+    }
+
+    // GET request for the user's expense list
+    try {
+        const expensesResponse = await fetch(`${API_URL}/expenses`, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+            },
+        });
+
+        if (expensesResponse.ok) {
+            const expensesData = await expensesResponse.json();
+            const lastExpensesElement = document.getElementById('expenses-list');
+            if (lastExpensesElement) {
+                const sortedExpenses = expensesData.sort((a, b) => new Date(b.dateCreated) - new Date(a.dateCreated));
+                if (sortedExpenses.length === 0) {
+                    lastExpensesElement.innerHTML = `<li style="border: 0px;"><p>Não há despesas registradas</p></li>`
+                } else {
+                    lastExpensesElement.innerHTML = sortedExpenses.map(expense => `
+                        <hr>
+                        <li>
+                            <h4>${expense.expenseLabel}</h4>
+                            <span style="display:none;">${expense.id}</span>
+                            <div>
+                                <p><span class="value">R$ ${expense.value.toFixed(2)}</span></p>
+                                <p><span class="type-tag">${typeTagMapping[expense.type] || expense.type}</span></p>
+                                <p>${new Date(expense.dateCreated).toLocaleDateString()}</p>
+                                <button class="delete-btn-desktop" id="delete-btn" data-id="expense-${expense.id}">
+                                    <i class="fas fa-trash-alt" data-id="expense-${expense.id}"></i>
+                                </button>
+                                <button class="edit-btn-desktop" id="edit-btn" data-id="expense-${expense.id}">
+                                    <i class="fas fa-pencil-alt" data-id="expense-${expense.id}"></i>
+                                </button>
+                            </div>
+                            <button class="delete-btn" id="delete-btn" data-id="expense-${expense.id}">
+                                <i class="fas fa-trash-alt" data-id="expense-${expense.id}"></i>
+                            </button>
+                            <button class="edit-btn" id="edit-btn" data-id="expense-${expense.id}">
+                                <i class="fas fa-pencil-alt" data-id="expense-${expense.id}"></i>
+                            </button>
+                        </li>
+                    `).join('');
+                }
+            }
+
+            const expensesByDate = expensesData.reduce((acc, expense) => {
+                const date = new Date(expense.dateCreated).toLocaleDateString();
+                if (!acc[date]) {
+                    acc[date] = 0;
+                }
+                acc[date] += expense.value;
+                return acc;
+            }, {});
+
+            const labels = Object.keys(expensesByDate).reverse();
+            const data = Object.values(expensesByDate).reverse();
+            const ctx = document.getElementById('expensesChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                  labels: labels,
+                  datasets: [{
+                    label: 'Despesas',
+                    data: data,
+                    borderColor: 'rgba(244, 67, 54, 0.3)',
+                    backgroundColor: 'rgba(244, 67, 54, 0.8)',
+                  }]
+                },
+                options: {
+                  scales: {
+                    y: {
+                      beginAtZero: true
+                    }
+                  }
+                }
+              });
+        } else {
+            console.error('Erro ao obter as transações do usuário');
+        }
+    } catch (error) {
+        console.error('Erro ao enviar a requisição');
+    }
+
+    document.getElementById('logout-btn').addEventListener('click', () => {
+        deleteCookie('accessToken');
+        window.location.href = 'index.html';
+    });
 
     // When the burger button is clicked, activates the hidden nav menu
     burger.addEventListener('click', () => {
         navLinks.classList.toggle('nav-active');
+    });
+
+    document.querySelectorAll('.delete-btn').forEach(button => {
+        button.addEventListener('click', async (event) => {
+            const id = event.target.getAttribute('data-id').split('-')[1];
+            const endpoint = event.target.getAttribute('data-id').split('-')[0];
+            try {
+                const response = await fetch(`${API_URL}/${endpoint}s/${id}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Authorization': `Bearer ${accessToken}`
+                    },
+                });
+
+                if (response.ok) {
+                    window.location.reload();
+                } else {
+                    console.error('Erro ao excluir o item');
+                }
+            } catch (error) {
+                console.error('Erro ao enviar a requisição de exclusão');
+            }
+        });
+    });
+
+    document.querySelectorAll('.delete-btn-desktop').forEach(button => {
+        button.addEventListener('click', async (event) => {
+            const id = event.target.getAttribute('data-id').split('-')[1];
+            const endpoint = event.target.getAttribute('data-id').split('-')[0];
+            try {
+                const response = await fetch(`${API_URL}/${endpoint}s/${id}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Authorization': `Bearer ${accessToken}`
+                    },
+                });
+
+                if (response.ok) {
+                    window.location.reload();
+                } else {
+                    console.error('Erro ao excluir o item');
+                }
+            } catch (error) {
+                console.error('Erro ao enviar a requisição de exclusão');
+            }
+        });
+    });
+
+    document.querySelectorAll('.edit-btn-desktop').forEach(button => {
+        button.addEventListener('click', async (event) => {
+            const id = event.target.getAttribute('data-id').split('-')[1];
+
+            try {
+                const response = await fetch(`${API_URL}/expenses/${id}`, {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': `Bearer ${accessToken}`
+                    },
+                });
+    
+                if (response.ok) {
+                    const data = await response.json();
+                    showEditModal('Editar registro', 'expense', data);
+                } else {
+                    showMessage('Erro ao obter os dados do registro');
+                }
+            } catch (error) {
+                showMessage('Erro ao enviar a requisição');
+            }
+
+            editExpenseForm.addEventListener('submit', async (event) => {
+                event.preventDefault();
+    
+                const data = {
+                    id: parseInt(id),
+                    expenseLabel: editExpenseLabel.value,
+                    value: parseFloat(editExpenseValue.value),
+                    type: editExpenseType.value
+                }
+        
+                try {
+                    const response = await fetch(`${API_URL}/expenses`, {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization': `Bearer ${accessToken}`
+                        },
+                        credentials: 'include',
+                        body: JSON.stringify(data)
+                    });
+        
+                    if (response.status === 200) {
+                        window.location.reload();
+                    } else {
+                        editModal.style.display = 'none';
+                        showMessage('Erro ao adicionar. Tente novamente.');
+                    }
+                } catch (error) {
+                    editModal.style.display = 'none';
+                    showMessage('Erro ao adicionar. Tente novamente.');
+                }
+            });
+        });
+    });
+
+    document.querySelectorAll('.edit-btn').forEach(button => {
+        button.addEventListener('click', async (event) => {
+            const id = event.target.getAttribute('data-id').split('-')[1];
+
+            try {
+                const response = await fetch(`${API_URL}/expenses/${id}`, {
+                    method: 'GET',
+                    headers: {
+                        'Authorization': `Bearer ${accessToken}`
+                    },
+                });
+    
+                if (response.ok) {
+                    const data = await response.json();
+                    showEditModal('Editar registro', 'expense', data);
+                } else {
+                    showMessage('Erro ao obter os dados do registro');
+                }
+            } catch (error) {
+                showMessage('Erro ao enviar a requisição');
+            }
+
+            editExpenseForm.addEventListener('submit', async (event) => {
+                event.preventDefault();
+    
+                const data = {
+                    id: parseInt(id),
+                    expenseLabel: editExpenseLabel.value,
+                    value: parseFloat(editExpenseValue.value),
+                    type: editExpenseType.value
+                }
+        
+                try {
+                    const response = await fetch(`${API_URL}/expenses`, {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization': `Bearer ${accessToken}`
+                        },
+                        credentials: 'include',
+                        body: JSON.stringify(data)
+                    });
+        
+                    if (response.status === 200) {
+                        window.location.reload();
+                    } else {
+                        editModal.style.display = 'none';
+                        showMessage('Erro ao editar. Tente novamente.');
+                    }
+                } catch (error) {
+                    editModal.style.display = 'none';
+                    showMessage('Erro ao editar. Tente novamente.');
+                }
+            });
+        });
     });
 });


### PR DESCRIPTION
## Por que esse PR foi criado? 🤔
Esse PR implementa as alterações estruturais e de estilização para os componentes visuais apresentados na página de despesas (expenses-dashboard). A partir do que foi adicionado nas estruturas do dashboard principal.

O código foi construído seguindo estrutura do [figma](https://www.figma.com/design/3tGEqFqB3QMECvs0SZqydx/Cashtrack-Wireframes).

## O que foi feito? 🧰
* Atualizado para incluir modais para adicionar e editar entradas e aprimorado o layout com novas seções para exibir o saldo, receitas e despesas do usuário.
* Adicionados modais para adicionar e editar despesas e atualizado o layout para incluir um gráfico para visualizar as despesas ao longo do tempo.
* Novo script para gerenciar a funcionalidade de adição de novas entradas de receitas e despesas, incluindo envios de formulários e interações modais.
* Novo script para gerenciar a funcionalidade de adição de novas entradas de despesas, incluindo envios de formulários e interações modais.
* Referências CSS atualizadas em dashboard.html e expenses-dashboard.html para usar dashboard.css em vez de index.css para melhor consistência de estilo.
* Metadados desnecessários removidos de docs/diagram-export-03-04-2025-21_25_18.png:Zone.Identifier.


## ✅ Como validar esse PR?
- Faça checkout para a branch do PR -> git checkout CT-029-add-dashboard-components
- Em um outro terminal, execute o backend localmente:
  - Rode o banco de dados local com as variáveis de ambiente configuradas no *projeto de backend* -> docker compose up -d --force-recreate --build db
  - Rode o *projeto de backend* com o gradle -> gradle bootRun
- Execute a aplicação *frontend* com a extensão live-server do VSCode
- Valide se os componentes estruturais e de estilo estão de acordo com wireframes e propostas do figma
- Valide o funcionamento da página e as integrações com o backend
- Certifique que o layout é responsivo e não quebra em dispositivos mobile ou médios