### PR TITLE
[CT-040] Remove cookie de accessToken e passa a lidar com autenticação por session storage

### DIFF
--- a/js/about.js
+++ b/js/about.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (parts.length === 2) return parts.pop().split(';').shift();
     }
 
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
     if(accessToken) {
         loginBtn.textContent = 'Seu Dashboard';
     }

--- a/js/add-new.js
+++ b/js/add-new.js
@@ -13,13 +13,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const messageModal = document.getElementById('messageModal');
     const modalMessage = document.getElementById('modalMessage');
 
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-    }
-
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
 
     //Function to show the add new expense/income modal
     function showModal(title, type) {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -72,24 +72,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     }
 
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
+    function deleteAccessToken() {
+        sessionStorage.removeItem('accessToken');
     }
 
-    function deleteCookie(name) {
-        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
-    }
-
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
     if (!accessToken) {
         window.location.href = 'index.html';
         return;
     }
 
     document.getElementById('logout-btn').addEventListener('click', () => {
-        deleteCookie('accessToken');
+        deleteAccessToken();
         window.location.href = 'index.html';
     });
 

--- a/js/expenses-add-new.js
+++ b/js/expenses-add-new.js
@@ -9,13 +9,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const messageModal = document.getElementById('messageModal');
     const closeModal = modal.querySelector('.close');
 
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-    }
-
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
 
     //Function to show the add new expense/income modal
     function showModal(title, type) {

--- a/js/expenses-dashboard.js
+++ b/js/expenses-dashboard.js
@@ -30,14 +30,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (parts.length === 2) return parts.pop().split(';').shift();
     }
 
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
     if (!accessToken) {
         window.location.href = 'index.html';
         return;
     }
 
-    function deleteCookie(name) {
-        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    function deleteAccessToken() {
+        sessionStorage.removeItem('accessToken');
+        window.location.href = 'index.html';  // Redirecionar para a página de login
     }
 
     function showMessage(message) {
@@ -178,7 +179,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     document.getElementById('logout-btn').addEventListener('click', () => {
-        deleteCookie('accessToken');
+        deleteAccessToken();
         window.location.href = 'index.html';
     });
 

--- a/js/incomes-add-new.js
+++ b/js/incomes-add-new.js
@@ -9,13 +9,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const messageModal = document.getElementById('messageModal');
     const closeModal = modal.querySelector('.close');
 
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-    }
-
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
 
     //Function to show the add new income/income modal
     function showModal(title, type) {

--- a/js/incomes-dashboard.js
+++ b/js/incomes-dashboard.js
@@ -24,20 +24,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     const messageModal = document.getElementById('messageModal');
     const modalMessage = document.getElementById('modalMessage');
 
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-    }
-
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
     if (!accessToken) {
         window.location.href = 'index.html';
         return;
     }
 
-    function deleteCookie(name) {
-        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    function deleteAccessToken() {
+        sessionStorage.removeItem('accessToken');
     }
 
     function showMessage(message) {
@@ -178,7 +172,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     document.getElementById('logout-btn').addEventListener('click', () => {
-        deleteCookie('accessToken');
+        deleteAccessToken();
         window.location.href = 'index.html';
     });
 

--- a/js/index.js
+++ b/js/index.js
@@ -6,13 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const closeModal = document.querySelector('.close');
     const loginBtn = document.getElementById('login-btn');
 
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-    }
-
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
     if(accessToken) {
         loginBtn.textContent = 'Seu Dashboard';
     }

--- a/js/login-form.js
+++ b/js/login-form.js
@@ -1,5 +1,5 @@
-const API_URL = 'https://cash-track-api-production.up.railway.app';
-//const API_URL = 'http://localhost:8080';
+//const API_URL = 'https://cash-track-api-production.up.railway.app';
+const API_URL = 'http://localhost:8080';
 
 document.getElementById('loginSubmit').addEventListener('click', async function(event) {
     event.preventDefault(); // Prevents the default form submission on the browser
@@ -60,16 +60,15 @@ document.getElementById('loginSubmit').addEventListener('click', async function(
     
             const elapsedTime = Date.now() - startTime;
             const remainingTime = minimumLoadingTime - elapsedTime;
-
-            const responseBody = await response.json();
     
             setTimeout(() => {
                 submitButton.classList.remove('loading');
     
                 switch (response.status) {
-                    case 200:
+                    case 204:
                         // Set the access token as a cookie
-                        document.cookie = `accessToken=${responseBody.accessToken}; path=/; max-age=3600; Secure; SameSite=None;`;
+                        const token = response.headers.get("Authorization");
+                        sessionStorage.setItem("accessToken", token);
 
                         modalMessage.textContent = 'Login realizado com sucesso!';
                         modal.style.display = 'block';

--- a/js/login.js
+++ b/js/login.js
@@ -3,13 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const navLinks = document.querySelector('.nav-links');
     const submitButtons = document.querySelectorAll('.submit-btn');
 
-    function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-    }
-
-    const accessToken = getCookie('accessToken');
+    const accessToken = sessionStorage.getItem('accessToken');
     if (accessToken) {
         window.location.href = 'dashboard.html';
     }


### PR DESCRIPTION
## Por que esse PR foi criado? 🤔
Esse PR inclui alterações para melhorar o processamento de tokens de acesso em vários arquivos JavaScript. As principais alterações envolvem a substituição do uso de cookies por `sessionStorage` para armazenar e gerenciar tokens de acesso.

## O que foi feito? 🧰
As principais mudanças incluem:

* Substituição da recuperação de token de acesso baseada em cookie por `sessionStorage`:
  * Alterado de `getCookie('accessToken')` para `sessionStorage.getItem('accessToken')`.
  * Substituído `getCookie('accessToken')` por `sessionStorage.getItem('accessToken')` e adicionada a função `deleteAccessToken` para remover o token de `sessionStorage`. Alterado de `getCookie('accessToken')` para `sessionStorage.getItem('accessToken')`.

* Atualizando o processo de login para armazenar o token de acesso em `sessionStorage` em vez de cookies:
  * Alterado o processo de login para armazenar o token de acesso em `sessionStorage` em vez de cookies e atualizada a URL da API para usar o servidor local para desenvolvimento.